### PR TITLE
design: 달력 커스터마이징 & Transaction 페이지 디자인 수정

### DIFF
--- a/src/components/transaction/AccountBoard.tsx
+++ b/src/components/transaction/AccountBoard.tsx
@@ -13,7 +13,7 @@ const AccountBoard: React.FC = () => {
   const formattedTotalBalance = account.totalBalance.toLocaleString();
 
   return (
-    <div className="w-[326px] h-[145px] m-[20px] p-[18px] text-left shadow-xl rounded-[20px] bg-white">
+    <div className="w-[326px] h-[145px] m-[20px] p-[18px] text-left shadow-md rounded-[20px] bg-white">
       <div>
         <div className="flex items-center">
           <img src="/img/logo3.png" alt="logo3" className="w-[32px] h-[32px]" />

--- a/src/components/transaction/HistoryOptionBoard.tsx
+++ b/src/components/transaction/HistoryOptionBoard.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { CgClose } from "react-icons/cg";
 import { IoCalendarOutline } from "react-icons/io5";
 import moment from "moment";
 import Calendar, { CalendarProps } from "react-calendar";
-import PeoridBtn from "../common/PeriodBtn";
 import "react-calendar/dist/Calendar.css";
+import PeriodBtn from "../common/PeriodBtn";
 import CalculateDate from "../../utils/CalculateDate";
 
 interface HistoryOptionBoardProps {
@@ -25,10 +25,12 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
 
   const handleStartToggleCalendar = () => {
     setStartCalendarOpen(!isStartCalendarOpen);
+    if (isEndCalendarOpen) setEndCalendarOpen(false); // Close end calendar if it's open
   };
 
   const handleEndToggleCalendar = () => {
     setEndCalendarOpen(!isEndCalendarOpen);
+    if (isStartCalendarOpen) setStartCalendarOpen(false); // Close start calendar if it's open
   };
 
   const handleStartDateChange: CalendarProps["onChange"] = (value) => {
@@ -65,12 +67,6 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
     setOrder(orderOption);
   };
 
-  useEffect(() => {
-    if (isStartDate && !selectedPeriod) {
-      setSelectedPeriod(undefined);
-    }
-  }, [isStartDate, selectedPeriod]);
-
   const periodOptions = [
     { month: 1, description: "1개월" },
     { month: 3, description: "3개월" },
@@ -99,7 +95,7 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
         <p className="py-[24px]">조회기간</p>
         <div id="btnGroup1" className="flex align-middle items-center">
           {periodOptions.map((option) => (
-            <PeoridBtn
+            <PeriodBtn
               key={option.month}
               month={option.month}
               description={option.description}
@@ -120,6 +116,8 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
                   onChange={handleStartDateChange}
                   value={isStartDate}
                   maxDate={isEndDate}
+                  locale="en-US" // 일요일부터 시작
+                  formatDay={(locale, date) => moment(date).format("DD")} // 숫자만 보여주기
                 />
               </div>
             )}
@@ -129,11 +127,13 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
             <p className="text-[12px]">{moment(isEndDate).format("YYYY-MM-DD")}</p>
             <IoCalendarOutline onClick={handleEndToggleCalendar} className="cursor-pointer" />
             {isEndCalendarOpen && (
-              <div className="absolute top-[50px] left-0 z-10 bg-white shadow-lg">
+              <div className="absolute top-[50px] left-auto right-0 z-10 bg-white shadow-lg">
                 <Calendar
                   onChange={handleEndDateChange}
                   value={isEndDate}
                   minDate={isStartDate}
+                  locale="en-US" // 일요일부터 시작
+                  formatDay={(locale, date) => moment(date).format("DD")} // 숫자만 보여주기
                 />
               </div>
             )}
@@ -144,7 +144,7 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
         <p className="py-[24px]">거래구분</p>
         <div className="flex align-middle items-center">
           {entireViewTexts.map((option) => (
-            <PeoridBtn
+            <PeriodBtn
               key={option.month}
               month={option.month}
               description={option.description}
@@ -160,7 +160,7 @@ function HistoryOptionBoard({ closeModal, confirmDate, confirmOption }: HistoryO
         <p className="py-[24px]">정렬순서</p>
         <div className="flex align-middle items-center">
           {orderTexts.map((option) => (
-            <PeoridBtn
+            <PeriodBtn
               key={option.month}
               month={option.month}
               description={option.description}


### PR DESCRIPTION
## 📍 제목
달력 커스터마이징 & Transaction 페이지 디자인 수정

## 📃 목적
React Calendar 라이브러리로 구현한 calendar UI를 수정하고 Transaction 페이지 UI를 수정합니다. 

## 📋 내용
- account board shadow xl → md 변경
- calendar 요일 순서 월화수목금토일 → 일월화수목금토
- 날짜 뒤에 붙는 '일' 삭제  ex) 1일 → 1
- endDate 설정하는 두 번째 캘린더를 열었을 때 화면 밖으로 열리는 문제 수정
- 캘린더 두 개가 겹쳐서 열리지 않도록 함 (하나씩 열리도록 수정)
- 오타 수정

## ❗ 체크리스트
<!-- 이번 PR을 제출하기 전에 확인할 사항들을 체크하세요. -->

- [x] 코드가 의도한 대로 동작합니다.
- [x] 기존 테스트를 모두 통과합니다.
- [x] 추가된 새로운 테스트를 모두 통과합니다.
- [x] 코드 스타일 규칙을 준수하였습니다.
- [x] PR 템플릿 형식에 맞게 작성하였습니다.
- [x] PR 이슈, 기여자, 라벨을 지정하였습니다.

## 📷 스크린샷 (선택)
<!-- 이번 PR에 대한 예시 화면을 스크린샷으로 첨부하세요. -->

## ❓ 추가 설명 (선택)
<!-- 이번 PR에 대한 추가 설명, 혹은 코드 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성하세요. -->

## 🔗 관련 문서 (선택)
<!-- 이번 PR과 관련된 문서나 참고 링크가 있다면 추가하세요. -->
