### PR TITLE
feat: 거래내역 수정 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
     "react-router-dom": "^6.23.1",
-    "tailwind-scrollbar-hide": "^1.1.7"
+    "tailwind-scrollbar-hide": "^1.1.7",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -260,11 +260,23 @@ class ApiClient implements userApi, interestApi, transactionApi, accountApi {
   // 거래 상세 내역 수정
   public async updateTransactionDetail(
     transactionHistoryId: number,
-  ): Promise<TransactionType> {
-    const response = await this.axiosInstance.request<TransactionType>({
-      method: "post",
-      url: `/transaction-history-details/transaction-history/${transactionHistoryId}`,
-    });
+    interests: { id: number; description: string; amount: number }[],
+  ): Promise<TransactionInterestDetail> {
+    const response =
+      await this.axiosInstance.request<TransactionInterestDetail>({
+        method: "post",
+        url: `/transaction-history-details/transaction-history/${transactionHistoryId}`,
+        data: {
+          interests: interests.map((interest) => ({
+            id: interest.id,
+            description: interest.description,
+            amount: interest.amount,
+          })),
+        },
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
     return response.data;
   }
 

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -266,19 +266,11 @@ class ApiClient implements userApi, interestApi, transactionApi, accountApi {
       await this.axiosInstance.request<TransactionInterestDetail>({
         method: "post",
         url: `/transaction-history-details/transaction-history/${transactionHistoryId}`,
-        data: {
-          interests: interests.map((interest) => ({
-            id: interest.id,
-            description: interest.description,
-            amount: interest.amount,
-          })),
-        },
+        data: { interests },
         headers: {
           "Content-Type": "application/json",
         },
       });
-    console.log("transactionHistoryId", transactionHistoryId);
-    console.log("interests는 과연?", interests);
     return response.data;
   }
 

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -277,6 +277,8 @@ class ApiClient implements userApi, interestApi, transactionApi, accountApi {
           "Content-Type": "application/json",
         },
       });
+    console.log("transactionHistoryId", transactionHistoryId);
+    console.log("interests는 과연?", interests);
     return response.data;
   }
 

--- a/src/components/transaction/ListCard.tsx
+++ b/src/components/transaction/ListCard.tsx
@@ -57,10 +57,22 @@ function ListCard({ id }: ListCardProps) {
           </div>
           <div>{transactionHistory.description}</div>
           <div className="flex justify-between mt-[20px] items-center">
-            <Tag
-              title={transactionHistory.categoryTitle}
-              color={transactionHistory.categoryColor}
-            />
+            <div className="flex flex-row">
+              <Tag
+                title={transactionHistory.categoryTitle}
+                color={transactionHistory.categoryColor}
+              />
+              {transactionHistory?.transactionHistoryDetails.map(
+                (detail, index) => (
+                  <div key={index}>
+                    <Tag
+                      title={detail.interest.title}
+                      color={detail.interest.color}
+                    />
+                  </div>
+                ),
+              )}
+            </div>
             <p
               className={
                 transactionHistory.type === "입금"

--- a/src/components/transaction/ModifyInterest.tsx
+++ b/src/components/transaction/ModifyInterest.tsx
@@ -1,6 +1,25 @@
 import React from "react";
 
-function ModifyInterest() {
+interface ModifyInterestProps {
+  amount: number;
+  description: string;
+  onAmountChange: (amount: number) => void;
+}
+
+function ModifyInterest({
+  amount,
+  description,
+  onAmountChange,
+}: ModifyInterestProps) {
+  // description이 10자를 넘어가면 자르기
+  const truncatedDescription =
+    description.length > 10 ? description.substring(0, 10) : description;
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newAmount = parseFloat(e.target.value) || 0;
+    onAmountChange(newAmount);
+  };
+
   return (
     <div className="w-[326px] h-[114px] rounded-[20px] mt-[16px] bg-white border-2 border-hanaSilver-300 flex justify-between px-[10px] py-[30px]">
       <div>
@@ -14,6 +33,7 @@ function ModifyInterest() {
               type="text"
               placeholder="내용을 입력하세요."
               className="w-[145px] h-[26px] border-b-2 text-[12px]"
+              defaultValue={truncatedDescription}
             />
             <p className="text-[8px] text-right mt-[4px] text-hanaSilver">
               최대 10자
@@ -21,9 +41,11 @@ function ModifyInterest() {
           </div>
           <div>
             <input
-              type="text"
+              type="number"
               placeholder="금액을 입력하세요."
               className="w-[92px] h-[26px] border-b-2 text-[12px]"
+              defaultValue={amount.toString()}
+              onChange={handleAmountChange}
             />
             <p className="text-[8px] text-right mt-[4px] text-hanaSilver">
               단위(원)

--- a/src/components/transaction/ModifyInterest.tsx
+++ b/src/components/transaction/ModifyInterest.tsx
@@ -7,7 +7,7 @@ interface ModifyInterestProps {
   interestId: number;
   onDescriptionChange: (description: string) => void;
   onAmountChange: (amount: number) => void;
-  onInterestChange: (interestId: number) => void; // 추가된 prop
+  onInterestChange: (interestId: number) => void;
 }
 
 function ModifyInterest({
@@ -17,20 +17,16 @@ function ModifyInterest({
   interestId,
   onDescriptionChange,
   onAmountChange,
-  onInterestChange, // 추가된 prop
+  onInterestChange,
 }: ModifyInterestProps) {
   const [childAmount, setChildAmount] = useState(amount);
   const [childDescription, setChildDescription] = useState(description);
-  const [childInterestId, setChildInterestId] = useState(interestId); // 추가된 상태
-
-  // description이 10자를 넘어가면 자르기
-  const truncatedDescription =
-    description.length > 10 ? description.substring(0, 10) : description;
+  const [childInterestId, setChildInterestId] = useState(interestId);
 
   useEffect(() => {
     setChildAmount(amount);
     setChildDescription(description);
-    setChildInterestId(interestId); // 추가된 useEffect
+    setChildInterestId(interestId);
   }, [amount, description, interestId]);
 
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -90,8 +86,8 @@ function ModifyInterest({
         <select
           name="interests"
           className="border-b-2 border-hanaSilver-300 text-[12px] pb-[3px]"
-          value={childInterestId} // 추가된 부분
-          onChange={handleInterestChange} // 추가된 핸들러
+          value={childInterestId}
+          onChange={handleInterestChange}
         >
           {interests?.map((interest) => (
             <option key={interest.interestId} value={interest.interestId}>

--- a/src/components/transaction/ModifyInterest.tsx
+++ b/src/components/transaction/ModifyInterest.tsx
@@ -43,7 +43,7 @@ function ModifyInterest({
             <input
               type="number"
               placeholder="금액을 입력하세요."
-              className="w-[92px] h-[26px] border-b-2 text-[12px]"
+              className="w-[92px] h-[26px] border-b-2 text-[12px] text-right"
               defaultValue={amount.toString()}
               onChange={handleAmountChange}
             />

--- a/src/components/transaction/ModifyInterest.tsx
+++ b/src/components/transaction/ModifyInterest.tsx
@@ -1,23 +1,54 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 interface ModifyInterestProps {
+  interests: TransactionInterestDetail[];
   amount: number;
   description: string;
+  interestId: number;
+  onDescriptionChange: (description: string) => void;
   onAmountChange: (amount: number) => void;
+  onInterestChange: (interestId: number) => void; // 추가된 prop
 }
 
 function ModifyInterest({
+  interests,
   amount,
   description,
+  interestId,
+  onDescriptionChange,
   onAmountChange,
+  onInterestChange, // 추가된 prop
 }: ModifyInterestProps) {
+  const [childAmount, setChildAmount] = useState(amount);
+  const [childDescription, setChildDescription] = useState(description);
+  const [childInterestId, setChildInterestId] = useState(interestId); // 추가된 상태
+
   // description이 10자를 넘어가면 자르기
   const truncatedDescription =
     description.length > 10 ? description.substring(0, 10) : description;
 
+  useEffect(() => {
+    setChildAmount(amount);
+    setChildDescription(description);
+    setChildInterestId(interestId); // 추가된 useEffect
+  }, [amount, description, interestId]);
+
+  const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newDescription = e.target.value;
+    setChildDescription(newDescription);
+    onDescriptionChange(newDescription);
+  };
+
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newAmount = parseFloat(e.target.value) || 0;
+    setChildAmount(newAmount);
     onAmountChange(newAmount);
+  };
+
+  const handleInterestChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newInterestId = parseInt(e.target.value);
+    setChildInterestId(newInterestId);
+    onInterestChange(newInterestId);
   };
 
   return (
@@ -33,7 +64,8 @@ function ModifyInterest({
               type="text"
               placeholder="내용을 입력하세요."
               className="w-[145px] h-[26px] border-b-2 text-[12px]"
-              defaultValue={truncatedDescription}
+              value={childDescription}
+              onChange={handleDescriptionChange}
             />
             <p className="text-[8px] text-right mt-[4px] text-hanaSilver">
               최대 10자
@@ -44,7 +76,7 @@ function ModifyInterest({
               type="number"
               placeholder="금액을 입력하세요."
               className="w-[92px] h-[26px] border-b-2 text-[12px] text-right"
-              defaultValue={amount.toString()}
+              value={childAmount.toString()}
               onChange={handleAmountChange}
             />
             <p className="text-[8px] text-right mt-[4px] text-hanaSilver">
@@ -58,8 +90,14 @@ function ModifyInterest({
         <select
           name="interests"
           className="border-b-2 border-hanaSilver-300 text-[12px] pb-[3px]"
+          value={childInterestId} // 추가된 부분
+          onChange={handleInterestChange} // 추가된 핸들러
         >
-          <option value="1">사과</option>
+          {interests?.map((interest) => (
+            <option key={interest.interestId} value={interest.interestId}>
+              {interest.title}
+            </option>
+          ))}
         </select>
       </div>
     </div>

--- a/src/components/transaction/TransactionList.tsx
+++ b/src/components/transaction/TransactionList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Tag from "../common/Tag";
 
@@ -14,15 +14,31 @@ const TransactionHistoryList: React.FC<TransactionListProps> = ({
   hasMore,
 }) => {
   const navigate = useNavigate();
+  const [expanded, setExpanded] = useState<{ [key: number]: boolean }>({});
 
   const handleClick = (id: number) => {
     navigate(`/transaction/detail/${id}`);
+  };
+
+  const toggleExpand = (id: number) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
   return (
     <div>
       <div className="w-[326px] h-[446px] border-2 rounded-[20px] bg-white mt-[8px] px-[12px] py-[6px] overflow-y-scroll scrollbar-hide">
         {transactions.map((data: TransactionType) => {
+          const isExpanded = expanded[data.id] || false;
+          const tags = data.transactionHistoryDetails.map((detail, index) => (
+            <div key={index} className="flex">
+              <Tag
+                title={detail.interest.title}
+                color={detail.interest.color}
+              />
+            </div>
+          ));
+          const displayedTags = isExpanded ? tags : tags.slice(0, 2);
+
           return (
             <div
               key={data.id}
@@ -46,17 +62,28 @@ const TransactionHistoryList: React.FC<TransactionListProps> = ({
                   {`${data.amount.toLocaleString()} 원`}
                 </div>
               </div>
-              <div className="flex justify-between">
-                <div className="flex flex-row items-center justify-center mt-[8px]">
-                  <Tag title={data.categoryTitle} color={data.categoryColor} />
-                  {data.transactionHistoryDetails?.map((detail, index) => (
-                    <div key={index} className="flex">
-                      <Tag
-                        title={detail.interest.title}
-                        color={detail.interest.color}
-                      />
+              <div className="flex justify-between items-start">
+                <div className="flex flex-col mt-[8px]">
+                  <div className="flex flex-row items-center">
+                    <Tag
+                      title={data.categoryTitle}
+                      color={data.categoryColor}
+                    />
+                    {displayedTags}
+                    {tags.length > 2 && !isExpanded && (
+                      <button
+                        onClick={() => toggleExpand(data.id)}
+                        className="ml-2 text-hanaSilver"
+                      >
+                        ...
+                      </button>
+                    )}
+                  </div>
+                  {isExpanded && (
+                    <div className="flex flex-row items-center mt-2">
+                      {tags.slice(2)}
                     </div>
-                  ))}
+                  )}
                 </div>
                 <div className="text-[12px] mt-[8px]">
                   {`잔액 ${data.balance.toLocaleString()} 원`}

--- a/src/pages/transaction/ModifyTransactionDetail.tsx
+++ b/src/pages/transaction/ModifyTransactionDetail.tsx
@@ -23,9 +23,13 @@ function ModifyTransactionDetail() {
   const [interestList, setInterestList] = useState<InterestDetail[]>([]);
   const [currAmount, setCurrAmount] = useState(0);
   const [errorMessage, setErrorMessage] = useState("");
+  const previousUrl = location.state?.from;
 
   function handleSaveClick() {
-    return false;
+    if (!errorMessage) {
+      // Save logic goes here
+      console.log("Transaction saved");
+    }
   }
 
   // 단일 거래내역 가져오기
@@ -86,7 +90,7 @@ function ModifyTransactionDetail() {
 
   const addList = () => {
     if (currAmount <= 0) {
-      setErrorMessage("잔액이 0원입니다");
+      setErrorMessage("더 이상 목록을 추가하실 수 없습니다.");
       return;
     }
     const newInterest = {
@@ -99,7 +103,12 @@ function ModifyTransactionDetail() {
 
   return (
     <section>
-      <Navbar title="거래내역수정" option={true} logo={false} path="" />
+      <Navbar
+        title="거래내역수정"
+        option={true}
+        logo={false}
+        path={previousUrl}
+      />
       <div className="flex flex-col items-center">
         {transactionHistory ? (
           <div className="w-[326px] h-[135px] mt-[20px] p-[22px] rounded-[20px] shadow-md text-left bg-white flex flex-col">
@@ -168,6 +177,7 @@ function ModifyTransactionDetail() {
             type="button"
             className="w-[144px] h-[48px] rounded-[15px] ml-[12px] text-white bg-hanaGreen"
             onClick={handleSaveClick}
+            disabled={!!errorMessage}
           >
             저장
           </button>

--- a/src/pages/transaction/ModifyTransactionDetail.tsx
+++ b/src/pages/transaction/ModifyTransactionDetail.tsx
@@ -24,6 +24,7 @@ function ModifyTransactionDetail() {
   const [currAmount, setCurrAmount] = useState(0);
   const [errorMessage, setErrorMessage] = useState("");
   const previousUrl = location.state?.from;
+  const [expanded, setExpanded] = useState(false);
 
   // 단일 거래내역 가져오기
   const {
@@ -39,6 +40,8 @@ function ModifyTransactionDetail() {
       return response;
     },
   });
+
+  console.log("확인확인", transactionHistory);
 
   const handleAmountChange = (id: number, newAmount: number) => {
     const newInterestList = interestList.map((detail) =>
@@ -119,6 +122,10 @@ function ModifyTransactionDetail() {
     }
   }
 
+  const handleExpandClick = () => {
+    setExpanded(!expanded);
+  };
+
   return (
     <section>
       <Navbar
@@ -134,21 +141,45 @@ function ModifyTransactionDetail() {
               {new Date(transactionHistory.createdAt).toLocaleString()}
             </div>
             <div>{transactionHistory.description}</div>
-            <div className="flex justify-between mt-[20px] items-center">
-              <div className="flex flex-row">
-                <Tag
-                  title={transactionHistory.categoryTitle}
-                  color={transactionHistory.categoryColor}
-                />
-                {transactionHistory.transactionHistoryDetails.map(
-                  (detail, index) => (
-                    <div key={index}>
-                      <Tag
-                        title={detail.interest.title}
-                        color={detail.interest.color}
-                      />
-                    </div>
-                  ),
+            <div className="flex justify-between mt-[20px] items-start">
+              <div className="flex flex-col">
+                <div className="flex flex-row">
+                  <Tag
+                    title={transactionHistory.categoryTitle}
+                    color={transactionHistory.categoryColor}
+                  />
+                  {transactionHistory.transactionHistoryDetails
+                    .slice(0, 2)
+                    .map((detail, index) => (
+                      <div key={index}>
+                        <Tag
+                          title={detail.interest.title}
+                          color={detail.interest.color}
+                        />
+                      </div>
+                    ))}
+                  {transactionHistory.transactionHistoryDetails.length > 2 && (
+                    <button
+                      onClick={handleExpandClick}
+                      className="ml-2 text-hanaSilver"
+                    >
+                      ...
+                    </button>
+                  )}
+                </div>
+                {expanded && (
+                  <div className="flex flex-row">
+                    {transactionHistory.transactionHistoryDetails
+                      .slice(2)
+                      .map((detail, index) => (
+                        <div key={index}>
+                          <Tag
+                            title={detail.interest.title}
+                            color={detail.interest.color}
+                          />
+                        </div>
+                      ))}
+                  </div>
                 )}
               </div>
               <p
@@ -157,6 +188,7 @@ function ModifyTransactionDetail() {
                     ? "text-hanaGreen"
                     : "text-hanaRed"
                 }
+                style={{ alignSelf: "flex-start" }}
               >
                 {`${transactionHistory.amount.toLocaleString()}원`}
               </p>

--- a/src/pages/transaction/ModifyTransactionDetail.tsx
+++ b/src/pages/transaction/ModifyTransactionDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { AiOutlinePlusCircle } from "react-icons/ai";
 import {
   CancleBtn,
@@ -24,13 +24,6 @@ function ModifyTransactionDetail() {
   const [currAmount, setCurrAmount] = useState(0);
   const [errorMessage, setErrorMessage] = useState("");
   const previousUrl = location.state?.from;
-
-  function handleSaveClick() {
-    if (!errorMessage) {
-      // Save logic goes here
-      console.log("Transaction saved");
-    }
-  }
 
   // 단일 거래내역 가져오기
   const {
@@ -66,12 +59,31 @@ function ModifyTransactionDetail() {
     }
   };
 
+  // 목록 업데이트
+  const updateTransactionDetail = useMutation({
+    mutationFn: async () => {
+      if (transactionHistory !== undefined && transactionId !== null) {
+        const response = await ApiClient.getInstance().updateTransactionDetail(
+          transactionId,
+          interestList,
+        );
+        return response;
+      }
+    },
+    onSuccess: (data) => {
+      console.log("Transaction saved successfully", data);
+    },
+    onError: (e) => {
+      console.error("Error saving transaction", e);
+    },
+  });
+
   useEffect(() => {
     if (transactionHistory) {
       setCurrAmount(transactionHistory.amount);
       const details = transactionHistory.transactionHistoryDetails.map(
         (detail) => ({
-          id: detail.index,
+          id: detail.id,
           amount: detail.amount,
           description: detail.description,
         }),
@@ -100,6 +112,12 @@ function ModifyTransactionDetail() {
     };
     setInterestList([...interestList, newInterest]);
   };
+
+  function handleSaveClick() {
+    if (!errorMessage) {
+      updateTransactionDetail.mutate();
+    }
+  }
 
   return (
     <section>

--- a/src/pages/transaction/Transaction.tsx
+++ b/src/pages/transaction/Transaction.tsx
@@ -68,7 +68,7 @@ function Transaction() {
 
   return (
     <section className="flex flex-col items-center flex-wrap">
-      <Navbar title="거래내역조회" option={true} logo={false} />
+      <Navbar title="거래내역조회" option={true} logo={false} path="/home" />
       <AccountBoard data={userAccounts} accountId={accountId} />
       <HistoryOption
         option={option}

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -20,3 +20,9 @@ interface TransactionType {
 interface TransactionDataType {
   transactionHistory: TransactionType[];
 }
+
+interface TransactionInterestDetail {
+  id: number;
+  amount: number;
+  description: string;
+}

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -23,6 +23,8 @@ interface TransactionDataType {
 
 interface TransactionInterestDetail {
   id: number;
+  interestId: number;
+  title: string;
   amount: number;
   description: string;
 }


### PR DESCRIPTION
## 📍 제목
거래내역 수정 기능 구현

## 📃 목적
기존에 구현한 UI에 api를 연결하여 실제 작동이 잘 이루어지게 합니다.

## 📋 내용
- 거래내역 쪼개기를 할 때, amount 내에서만 쪼갤 수 있도록 하기
- 기존 관심사와 description을 불러올 수 있도록 하기
- 수정 버튼을 누르면 관심사 list가 update 될 수 있도록 하기
- apiClient에 해당 기능 추가

## ❗ 체크리스트
<!-- 이번 PR을 제출하기 전에 확인할 사항들을 체크하세요. -->

- [x] 코드가 의도한 대로 동작합니다.
- [x] 기존 테스트를 모두 통과합니다.
- [x] 추가된 새로운 테스트를 모두 통과합니다.
- [x] 코드 스타일 규칙을 준수하였습니다.
- [x] PR 템플릿 형식에 맞게 작성하였습니다.
- [x] PR 이슈, 기여자, 라벨을 지정하였습니다.

## 📷 스크린샷 (선택)
<!-- 이번 PR에 대한 예시 화면을 스크린샷으로 첨부하세요. -->

## ❓ 추가 설명 (선택)
<!-- 이번 PR에 대한 추가 설명, 혹은 코드 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성하세요. -->

## 🔗 관련 문서 (선택)
<!-- 이번 PR과 관련된 문서나 참고 링크가 있다면 추가하세요. -->
